### PR TITLE
Fix sign-in-with-google-button border to none

### DIFF
--- a/src/components/custom-button/custom-button.styles.jsx
+++ b/src/components/custom-button/custom-button.styles.jsx
@@ -27,10 +27,10 @@ const invertedButtonStyles = css`
 const googleSignInStyles = css`
   background-color: #4285f4;
   color: white;
+  border: none;
 
   &:hover {
     background-color: #357ae8;
-    border: none;
   }
 `;
 


### PR DESCRIPTION
Sign-in with google button has border when mouse is not hover. This PR fixes this